### PR TITLE
Use CNI's Copilot hostname for non dot-com domains

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,8 @@
   "permissions": [
     "storage",
     "cookies",
-    "*://*.conde.io/*"
+    "*://*.conde.io/*",
+    "*://*.cni.digital/*"
   ],
   "background": {
     "scripts": [
@@ -42,6 +43,7 @@
         "*://*.vanityfair.com/*",
         "*://*.vogue.com/*",
         "*://*.vogue.de/*",
+        "*://*.cni.digital/*",
         "*://*.wmagazine.com/*",
         "*://*.wired.com/*"
       ],


### PR DESCRIPTION
Thanks for the great extension!

Currently ``copilot-chrome-extension`` triggers on ``vogue.de``. Unfortunately, the vogue.de editorial interface is hosted separately from the CN US brands, so authentication fails.

This PR adds support for vogue.de and future Condé Nast International brands by choosing the Copilot hostname dynamically.